### PR TITLE
Fix/setup fields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="python_graphql_client",
-    version="0.1.0",
+    version="0.1.1",
     description="Python GraphQL Client",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     keywords="api graphql client",
-    url="https://github.com/SMARTeacher/python-graphql-client",  # TODO change this
+    url="https://github.com/prodigyeducation/python-graphql-client",
     author="Justin Krinke",
     author_email="opensource@prodigygame.com",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,19 @@
 """Configuration for python project."""
 
+from os import path
+
 from setuptools import setup
+
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
+    long_description = f.read()
 
 setup(
     name="python_graphql_client",
     version="0.1.0",
     description="Python GraphQL Client",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
## What kind of change does this PR introduce?

<!-- > (Bug fix, feature, docs update, ...) -->

Mainly a bug fix.

## What is the current behavior?

<!-- > (You can also link to an open issue here). -->

Right now if you look at the [PyPi homepage](https://pypi.org/project/python-graphql-client/) for the project and click on the homepage link on the left, you'll be directed to the old repository location within the `SMARTeacher` organization.

![](https://user-images.githubusercontent.com/4990214/72776006-97931a00-3bde-11ea-9723-b7c88947f18f.gif)

Also notice that the description page on PyPI is blank. This does not give the user any clear information on what the project is about.

## What is the new behavior?

Changing the url means that PyPi should now point to the new github repository that is public.

Following the guide [Making a pypi friendly readme](https://packaging.python.org/guides/making-a-pypi-friendly-readme/), the setup function now uses the README file as what to show in the project description on PyPi. Take a peek at the [test pypi repository](https://test.pypi.org/project/python-graphql-client/) to see what the output looks like


## **Does this PR introduce a breaking change?**

<!-- > What changes might users need to make in their application due to this PR? -->

No breaking changes to the functionality of the project. Just fixes a bug with how the project looks on PyPi.

## Other information

First Pull Request of the project :tada: 