### PR TITLE
feat: create pypi publish github action

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,0 +1,26 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,7 +8,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout code for release
+        uses: actions/checkout@v1
       - name: Set up Python
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
## What kind of change does this PR introduce?

<!-- > (Bug fix, feature, docs update, ...) -->

Feature related to #6.

## What is the current behavior?

<!-- > (You can also link to an open issue here). -->

Currently the release process is as follows:

1. Pull the latest code in master.
2. Update the version number in `setup.py`.
3. Build the distribution.
4. Upload the distribution to pypi.
5. Create a git tag in github for the release.

While this is ok, there are a lot of manual steps to this which could fail due to a manual error.

## What is the new behavior?

With github actions, whenever a new release is created for the repository, this github action will trigger and try to build and deploy the package to pypi. The build will use the code based on the git sha of the release.

This change will still require the manual process of upgrading the version number in setup.py before releasing, but it at least removes the manual steps of having to build and deploy the project.

## **Does this PR introduce a breaking change?**

<!-- > What changes might users need to make in their application due to this PR? -->

No breaking changes to the project :tada: 

## Other information


