### PR TITLE
Allow overriding headers when making requests

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -28,7 +28,7 @@ git clone git@github.com:prodigyeducation/python-graphql-client.git
 After that you'll need to install the required python dependencies as well as development dependencies for linting the project.
 
 ```bash
-pip install -e .["dev"]
+pip install -e ."[dev]"
 ```
 
 Finally, you should make sure `pre-commit` has setup the git hooks on your machine by running the following command. This will run the automated checks every time you commit.

--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -25,18 +25,34 @@ class GraphqlClient:
 
         return json
 
-    def execute(self, query: str, variables: dict = None, operation_name: str = None):
+    def __request_headers(self, headers: dict = None) -> dict:
+        return {**self.headers, **headers} if headers else self.headers
+
+    def execute(
+        self,
+        query: str,
+        variables: dict = None,
+        operation_name: str = None,
+        headers: dict = None,
+    ):
         """Make synchronous request to graphQL server."""
         request_body = self.__request_body(
             query=query, variables=variables, operation_name=operation_name
         )
 
-        result = requests.post(self.endpoint, json=request_body, headers=self.headers)
+        result = requests.post(
+            self.endpoint, json=request_body, headers=self.__request_headers(headers),
+        )
+
         result.raise_for_status()
         return result.json()
 
     async def execute_async(
-        self, query: str, variables: dict = None, operation_name: str = None
+        self,
+        query: str,
+        variables: dict = None,
+        operation_name: str = None,
+        headers: dict = None,
     ):
         """Make asynchronous request to graphQL server."""
         request_body = self.__request_body(
@@ -45,6 +61,8 @@ class GraphqlClient:
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                self.endpoint, json=request_body, headers=self.headers
+                self.endpoint,
+                json=request_body,
+                headers=self.__request_headers(headers),
             ) as response:
                 return await response.json()

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -88,14 +88,14 @@ class TestGraphqlClientExecute(unittest.TestCase):
             headers={"Content-Type": "application/json", "Existing": "123",},
         )
         query = ""
-        client.execute(query=query, headers={"Existing": "123", "New": "foo"})
+        client.execute(query=query, headers={"Existing": "456", "New": "foo"})
 
         post_mock.assert_called_once_with(
             "http://www.test-api.com/",
             json={"query": query},
             headers={
                 "Content-Type": "application/json",
-                "Existing": "123",
+                "Existing": "456",
                 "New": "foo",
             },
         )
@@ -190,14 +190,14 @@ class TestGraphqlClientExecuteAsync(AioHTTPTestCase):
         )
         query = ""
 
-        await client.execute_async("", headers={"Existing": "123", "New": "foo"})
+        await client.execute_async("", headers={"Existing": "456", "New": "foo"})
 
         mock_post.assert_called_once_with(
             "http://www.test-api.com/",
             json={"query": query},
             headers={
                 "Content-Type": "application/json",
-                "Existing": "123",
+                "Existing": "456",
                 "New": "foo",
             },
         )

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -83,13 +83,21 @@ class TestGraphqlClientExecute(unittest.TestCase):
     @patch("python_graphql_client.graphql_client.requests.post")
     def test_execute_query_with_headers(self, post_mock):
         """Sends a graphql POST request with headers."""
-        headers = {"Content-Type": "application/json"}
-        client = GraphqlClient(endpoint="http://www.test-api.com/", headers=headers)
+        client = GraphqlClient(
+            endpoint="http://www.test-api.com/",
+            headers={"Content-Type": "application/json", "Existing": "123",},
+        )
         query = ""
-        client.execute(query)
+        client.execute(query=query, headers={"Existing": "123", "New": "foo"})
 
         post_mock.assert_called_once_with(
-            "http://www.test-api.com/", json={"query": query}, headers=headers
+            "http://www.test-api.com/",
+            json={"query": query},
+            headers={
+                "Content-Type": "application/json",
+                "Existing": "123",
+                "New": "foo",
+            },
         )
 
     @patch("python_graphql_client.graphql_client.requests.post")
@@ -176,14 +184,22 @@ class TestGraphqlClientExecuteAsync(AioHTTPTestCase):
     async def test_execute_query_with_headers(self, mock_post):
         """Sends a graphql POST request with headers."""
         mock_post.return_value.__aenter__.return_value.json = CoroutineMock()
-        headers = {"Content-Type": "application/json"}
-        client = GraphqlClient(endpoint="http://www.test-api.com/", headers=headers)
+        client = GraphqlClient(
+            endpoint="http://www.test-api.com/",
+            headers={"Content-Type": "application/json", "Existing": "123",},
+        )
         query = ""
 
-        await client.execute_async(query)
+        await client.execute_async("", headers={"Existing": "123", "New": "foo"})
 
         mock_post.assert_called_once_with(
-            "http://www.test-api.com/", json={"query": query}, headers=headers
+            "http://www.test-api.com/",
+            json={"query": query},
+            headers={
+                "Content-Type": "application/json",
+                "Existing": "123",
+                "New": "foo",
+            },
         )
 
     @unittest_run_loop


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature. resolves #9

## What is the current behavior?

`GraphqlClient` only takes headers when it gets created as follows.
If some of the headers need to vary request to request, a new client needs to be instantiated every time.

```py
client1 = GraphqlClient(
    endpoint="http://www.test-api.com/", 
    headers={
        "Content-Type": "application/json", 
        "Authorization": "Bearer foo123"
    }
)
client1.execute(query)

client2 = GraphqlClient(
    endpoint="http://www.test-api.com/", 
    headers={
        "Content-Type": "application/json", 
        "Authorization": "Bearer bar456"
    }
)
client2.execute(query)
```

I think this makes the users' code look verbose and it will get even more verbose as we add additional parameters such as `timeout`, `numOfConnections` to the constructor.

## What is the new behavior?

`GraphqlClient`'s `execute` method takes `headers` so that users are able to override some of the header values they specified when instantiating the client.

```py
client = GraphqlClient(
    endpoint="http://www.test-api.com/", 
    headers={
        "Content-Type": "application/json"
    }
)

client.execute(query, headers={"Authorization": "Bearer foo123"})
client.execute(query, headers={"Authorization": "Bearer bar456"})
client.execute(query, headers={"Authorization": "Bearer baz789"})
```

This change will also make it easier for users to write unit tests by allowing them to verify what `headers` were passed to the mocked `execute` method as well as `query` and `variables`.

## **Does this PR introduce a breaking change?**

I don't believe this is going to be a breaking change because the new parameter is a named parameter.

## Other information

This PR also contains a minor change to CONTRIBUTING.md so that contributors are able to install dependencies properly.
