### PR TITLE
feat: create config for linter checks

### DIFF
--- a/.github/workflows/python-ci-checks.yml
+++ b/.github/workflows/python-ci-checks.yml
@@ -18,6 +18,11 @@ jobs:
           python -m pip install --upgrade pip
           # Install all necessary packages, including dev dependencies.
           pip install -e ."[dev]"
+      - name: Check format with black
+        run: |
+          # Check all python files to see if black would format them.
+          # If black would format them, then the check fails.
+          black --check **/*.py
       - name: Lint with flake8
         run: |
           # exit-zero treats all errors as warnings.
@@ -25,8 +30,3 @@ jobs:
       - name: Test with unittest
         run: |
           python -m unittest discover -s tests/
-      - name: Check format with black
-        run: |
-          # Check all python files to see if black would format them.
-          # If black would format them, then the check fails.
-          black --check **/*.py

--- a/.github/workflows/python-ci-checks.yml
+++ b/.github/workflows/python-ci-checks.yml
@@ -1,4 +1,4 @@
-name: Python application
+name: Python CI Checks
 
 on: [push]
 

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,0 +1,32 @@
+name: Python application
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code to check
+        uses: actions/checkout@v1
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Install all necessary packages, including dev dependencies.
+          pip install -e ."[dev]"
+      - name: Lint with flake8
+        run: |
+          # exit-zero treats all errors as warnings.
+          flake8 .
+      - name: Test with unittest
+        run: |
+          python -m unittest discover -s tests/
+      - name: Check format with black
+        run: |
+          # Check all python files to see if black would format them.
+          # If black would format them, then the check fails.
+          black --check **/*.py


### PR DESCRIPTION
## What kind of change does this PR introduce?

<!-- > (Bug fix, feature, docs update, ...) -->

Chore for integrating linter checks into github. Addresses #7.


## What is the current behavior?

<!-- > (You can also link to an open issue here). -->

Right now, assuming pre-commit and out linter packages are installed locally, linter checks should be run on the locally changed files before committing. While this is a good first check, the git hook checsk only run against changed files and not the whole project, so there is still a chance that one of our linter rules fail.

## What is the new behavior?

Whenever someone pushes to the repository, that version of the project in git will run the github action added here. This action will run our core checks (black, flake8, unittest) and will block the PR if any of the checks fail.

## **Does this PR introduce a breaking change?**

<!-- > What changes might users need to make in their application due to this PR? -->

No feature changes included here.

## Other information


If you want to test this PR, you can branch off of `add-ci-linter-checks` and try and push changes that would cause one or more of our linters to fail. To avoid the local git hook warnings, you can skip the git hook checks by adding the `--no-verify` flag when committing.

```bash
git add .
git commit --no-verify
```