### PR TITLE
Github Actions status badges 🏅

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+![Python CI Checks](https://github.com/prodigyeducation/python-graphql-client/workflows/Python%20CI%20Checks/badge.svg)
+![Upload Python Package](https://github.com/prodigyeducation/python-graphql-client/workflows/Upload%20Python%20Package/badge.svg)
 
 # Python GraphQL Client
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs

## What is the current behavior?

No Github Actions status badges

## What is the new behavior?

Don't they look cool, are they?

<img width="510" alt="image" src="https://user-images.githubusercontent.com/5466341/73140139-6b92f100-4043-11ea-8a1e-c519a3f1789f.png">

## **Does this PR introduce a breaking change?**

No, Just docs

## Other information


