### PR TITLE
ignore E231 for flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 max-line-length = 88
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
-    E203,
+    E203, E231
 no-isort-config = True


### PR DESCRIPTION
## What kind of change does this PR introduce?

<!-- > (Bug fix, feature, docs update, ...) -->
This PR makes flake8 ignore E231. I personally like to have space after comma, but I didn't find a way to change the Black rule for this one. Therefore, suppressing flake8 to avoid conflict.


## What is the current behavior?

<!-- > (You can also link to an open issue here). -->



## What is the new behavior?



## **Does this PR introduce a breaking change?**

<!-- > What changes might users need to make in their application due to this PR? -->



## Other information


