### PR TITLE
Bug/fix black flake8 conflict

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 max-line-length = 88
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
-    E203,
+    E203, E231
 no-isort-config = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 max-line-length = 88
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
-    E203, E231
+    E203,
 no-isort-config = True

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -85,7 +85,7 @@ class TestGraphqlClientExecute(unittest.TestCase):
         """Sends a graphql POST request with headers."""
         client = GraphqlClient(
             endpoint="http://www.test-api.com/",
-            headers={"Content-Type": "application/json", "Existing": "123",},
+            headers={"Content-Type": "application/json", "Existing": "123"},
         )
         query = ""
         client.execute(query=query, headers={"Existing": "456", "New": "foo"})
@@ -186,7 +186,7 @@ class TestGraphqlClientExecuteAsync(AioHTTPTestCase):
         mock_post.return_value.__aenter__.return_value.json = CoroutineMock()
         client = GraphqlClient(
             endpoint="http://www.test-api.com/",
-            headers={"Content-Type": "application/json", "Existing": "123",},
+            headers={"Content-Type": "application/json", "Existing": "123"},
         )
         query = ""
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

<!-- > (Bug fix, feature, docs update, ...) -->
The conflict happens because two dictionaries have trailing comma. Removing those comma should fix the flake8 warning.


## What is the current behavior?

<!-- > (You can also link to an open issue here). -->



## What is the new behavior?



## **Does this PR introduce a breaking change?**

<!-- > What changes might users need to make in their application due to this PR? -->



## Other information


