### PR TITLE
feat: add pull_request as trigger for ci checks

### DIFF
--- a/.github/workflows/python-ci-checks.yml
+++ b/.github/workflows/python-ci-checks.yml
@@ -1,6 +1,6 @@
 name: Python CI Checks
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
## What kind of change does this PR introduce?

<!-- > (Bug fix, feature, docs update, ...) -->

Bug fix

## What is the current behavior?

<!-- > (You can also link to an open issue here). -->

Pull requests from forked repositories are not running the Github action CI checks. They base repository should be running the checks no matter if the PR is coming from a forked branch or not.

## What is the new behavior?

This is just a test, but I'm hoping that this addition here will fix it and have the CI checks on this PR.

## **Does this PR introduce a breaking change?**

<!-- > What changes might users need to make in their application due to this PR? -->

No I don't think so.

## Other information


