### PR TITLE
Fix/flake8 consistent checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: ""
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-docstrings]
+        additional_dependencies: [flake8-docstrings, flake8-isort]
   - repo: local
     hooks:
       - id: test

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
             "pre-commit",
             "black",
             "flake8",
+            "flake8-docstrings",
             "flake8-black",
             "flake8-isort",
             "gitchangelog",


### PR DESCRIPTION
## What kind of change does this PR introduce?

<!-- > (Bug fix, feature, docs update, ...) -->

Bug fix

## What is the current behavior?

<!-- > (You can also link to an open issue here). -->

Right now the prec-commit check confirms that functions pass the `flake8` and `flake8-docstring` linter checks, while the github action CI checks confirm that `flake8`, `flake8-black`, and `flake8-isort` run. This means there is an inconsistentcy between the linter checks run locally and the ones run remotely.

## What is the new behavior?

Now the flake8 extensions are consistent between the pre-commit and remote CI runners.

## **Does this PR introduce a breaking change?**

<!-- > What changes might users need to make in their application due to this PR? -->

No breaking change :tada: 

## Other information

Sorry for making this mistake :cry: 