### PR TITLE
GraphQL Subscriptions Support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ pip install python-graphql-client
 
 ## Usage
 
+- Query/Mutation
+
 ```python
 from python_graphql_client import GraphqlClient
 
@@ -43,6 +45,31 @@ import asyncio
 
 data = asyncio.run(client.execute_async(query=query, variables=variables))
 print(data)  # => {'data': {'country': {'code': 'CA', 'name': 'Canada'}}}
+```
+
+- Subscription
+
+```python
+from python_graphql_client import GraphqlClient
+
+# Instantiate the client with a websocket endpoint.
+client = GraphqlClient(endpoint="wss://www.your-api.com/graphql")
+
+# Create the query string and variables required for the request.
+query = """
+    subscription onMessageAdded {
+        messageAdded
+    }
+"""
+
+# Asynchronous request
+import asyncio
+
+asyncio.run(client.subscribe(query=query, handle=print))
+# => {'data': {'messageAdded': 'Error omnis quis.'}}
+# => {'data': {'messageAdded': 'Enim asperiores omnis.'}}
+# => {'data': {'messageAdded': 'Unde ullam consequatur quam eius vel.'}}
+# ...
 ```
 
 ## Roadmap

--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -1,10 +1,13 @@
 """Module containing graphQL client."""
 import json
+import logging
 from typing import Callable
 
 import aiohttp
 import requests
 import websockets
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
 
 
 class GraphqlClient:
@@ -79,6 +82,8 @@ class GraphqlClient:
         headers: dict = None,
     ):
         """Make asynchronous request for GraphQL subscription."""
+        connection_init_message = json.dumps({"type": "connection_init", "payload": {}})
+
         request_body = self.__request_body(
             query=query, variables=variables, operation_name=operation_name
         )
@@ -89,7 +94,11 @@ class GraphqlClient:
         async with websockets.connect(
             self.endpoint, subprotocols=["graphql-ws"]
         ) as websocket:
+            await websocket.send(connection_init_message)
             await websocket.send(request_message)
             async for response_message in websocket:
                 response_body = json.loads(response_message)
-                handle(response_body["payload"])
+                if response_body["type"] == "connection_ack":
+                    logging.info("the server accepted the connection")
+                else:
+                    handle(response_body["payload"])

--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -1,7 +1,10 @@
 """Module containing graphQL client."""
+import json
+from typing import Callable
 
 import aiohttp
 import requests
+import websockets
 
 
 class GraphqlClient:
@@ -66,3 +69,27 @@ class GraphqlClient:
                 headers=self.__request_headers(headers),
             ) as response:
                 return await response.json()
+
+    async def subscribe(
+        self,
+        query: str,
+        handle: Callable,
+        variables: dict = None,
+        operation_name: str = None,
+        headers: dict = None,
+    ):
+        """Make asynchronous request for GraphQL subscription."""
+        request_body = self.__request_body(
+            query=query, variables=variables, operation_name=operation_name
+        )
+        request_message = json.dumps(
+            {"type": "start", "id": "1", "payload": request_body}
+        )
+
+        async with websockets.connect(
+            self.endpoint, subprotocols=["graphql-ws"]
+        ) as websocket:
+            await websocket.send(request_message)
+            async for response_message in websocket:
+                response_body = json.loads(response_message)
+                handle(response_body["payload"])

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     author_email="opensource@prodigygame.com",
     license="MIT",
     packages=["python_graphql_client"],
-    install_requires=["aiohttp==3.6.2", "requests==2.22.0"],
+    install_requires=["aiohttp==3.6.2", "requests==2.22.0", "websockets==8.1"],
     extras_require={
         "dev": [
             "pre-commit",

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -1,7 +1,7 @@
 """Tests for main graphql client module."""
 
 from unittest import IsolatedAsyncioTestCase, TestCase
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from aiohttp import web
 from requests.exceptions import HTTPError
@@ -215,4 +215,33 @@ class TestGraphqlClientExecuteAsync(IsolatedAsyncioTestCase):
             "http://www.test-api.com/",
             json={"query": query, "operationName": operation_name},
             headers={},
+        )
+
+
+class TestGraphqlClientSubscriptions(IsolatedAsyncioTestCase):
+    @patch("websockets.connect")
+    async def test_subscribe(self, mock_connect):
+        mock_websocket = mock_connect.return_value.__aenter__.return_value
+        mock_websocket.send = AsyncMock()
+        mock_websocket.__aiter__.return_value = [
+            '{"type": "data", "id": "1", "payload": {"data": {"messageAdded": "test1"}}}',
+            '{"type": "data", "id": "1", "payload": {"data": {"messageAdded": "test2"}}}',
+        ]
+
+        client = GraphqlClient(endpoint="ws://www.test-api.com/graphql")
+        query = """
+            subscription onMessageAdded {
+                messageAdded
+            }
+        """
+
+        mock_handle = MagicMock()
+
+        await client.subscribe(query=query, handle=mock_handle)
+
+        mock_handle.assert_has_calls(
+            [
+                call({"data": {"messageAdded": "test1"}}),
+                call({"data": {"messageAdded": "test2"}}),
+            ]
         )

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -219,13 +219,16 @@ class TestGraphqlClientExecuteAsync(IsolatedAsyncioTestCase):
 
 
 class TestGraphqlClientSubscriptions(IsolatedAsyncioTestCase):
+    """Test cases for subscribing GraphQL subscriptions."""
+
     @patch("websockets.connect")
     async def test_subscribe(self, mock_connect):
+        """Subsribe a GraphQL subscription."""
         mock_websocket = mock_connect.return_value.__aenter__.return_value
         mock_websocket.send = AsyncMock()
         mock_websocket.__aiter__.return_value = [
-            '{"type": "data", "id": "1", "payload": {"data": {"messageAdded": "test1"}}}',
-            '{"type": "data", "id": "1", "payload": {"data": {"messageAdded": "test2"}}}',
+            '{"type": "data", "id": "1", "payload": {"data": {"messageAdded": "one"}}}',
+            '{"type": "data", "id": "1", "payload": {"data": {"messageAdded": "two"}}}',
         ]
 
         client = GraphqlClient(endpoint="ws://www.test-api.com/graphql")
@@ -241,7 +244,7 @@ class TestGraphqlClientSubscriptions(IsolatedAsyncioTestCase):
 
         mock_handle.assert_has_calls(
             [
-                call({"data": {"messageAdded": "test1"}}),
-                call({"data": {"messageAdded": "test2"}}),
+                call({"data": {"messageAdded": "one"}}),
+                call({"data": {"messageAdded": "two"}}),
             ]
         )


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds support for GraphQL subscriptions to the client. (fix #4)

## What is the current behavior?

The client only supports GraphQL queries and mutations.

## What is the new behavior?

The client also supports GraphQL subscriptions.

This PR implements the `subscribe` method of the `GraphqlClient` class. The `websockets` dependency is added to the project because GraphQL subscriptions are executed over WebSocket unlike GraphQL queries and mutations.

It wasn't easy to find public APIs that support GraphQL subscriptions. So, I wrote [a very simple API](https://3wqzw.sse.codesandbox.io/) myself for understanding how GraphQL subscriptions work and also for performing some manual testing.

![image](https://user-images.githubusercontent.com/5466341/79056123-05b90d00-7c21-11ea-81e9-80764aed8ce9.png)

The above screenshot is what I captured from the network tab of Chrome Developer Tools after initiating the `messageAdded` subscription. Once the endpoint receives a request in the form of `{"type": "start", "id": "1", "payload": {"query": ..., "variables": ...}}`, it sends back with a series of responses like `{"type": "start", "id": "1", "payload": {"data": ...}}`.

My implementation in this PR is simply based on these behaviors between the client and the server that I observed on the Apollo Playground tool. There must be huge room for improvement but I hope this serves as the first step in enabling the client to support all GraphQL operations.

Here're the manual testing results.

```py
import asyncio
from python_graphql_client import GraphqlClient

client = GraphqlClient(endpoint="wss://3wqzw.sse.codesandbox.io/graphql")

query = """
    subscription onMessageAdded {
        messageAdded
    }
"""

asyncio.run(client.subscribe(query=query, handle=print))
```

```sh
$ python tests/dale.py                                                    
{'data': {'messageAdded': 'Vero autem voluptatem architecto.'}}
{'data': {'messageAdded': 'Est quo sunt est repellendus perspiciatis qui culpa reprehenderit.'}}
{'data': {'messageAdded': 'Inventore nemo quos illo magni voluptates autem quia.'}}
{'data': {'messageAdded': 'Eos omnis minima.'}}
{'data': {'messageAdded': 'Perspiciatis id vitae iure provident omnis assumenda sapiente eum.'}}
{'data': {'messageAdded': 'Dolores autem est.'}}
{'data': {'messageAdded': 'Accusantium temporibus impedit soluta beatae occaecati unde magnam sit.'}}
```

## Does this PR introduce a breaking change?

No. This doesn't touch any of the existing functionalities.

## Other information

