### PR TITLE
Subscription headers

### DIFF
--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -47,7 +47,9 @@ class GraphqlClient:
         )
 
         result = requests.post(
-            self.endpoint, json=request_body, headers=self.__request_headers(headers),
+            self.endpoint,
+            json=request_body,
+            headers=self.__request_headers(headers),
         )
 
         result.raise_for_status()

--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -92,7 +92,9 @@ class GraphqlClient:
         )
 
         async with websockets.connect(
-            self.endpoint, subprotocols=["graphql-ws"]
+            self.endpoint,
+            subprotocols=["graphql-ws"],
+            extra_headers=self.__request_headers(headers)
         ) as websocket:
             await websocket.send(connection_init_message)
             await websocket.send(request_message)
@@ -100,5 +102,7 @@ class GraphqlClient:
                 response_body = json.loads(response_message)
                 if response_body["type"] == "connection_ack":
                     logging.info("the server accepted the connection")
+                elif response_body["type"] == "ka":
+                    logging.info("the server sent a keep alive message")
                 else:
                     handle(response_body["payload"])


### PR DESCRIPTION
headers are added to the websockets connect method
keep alive message is handled without crashing

## What kind of change does this PR introduce?
This feature allows the passing of header information in the subscribe method. Also it handles a keep alive message

## What is the current behavior?
https://github.com/prodigyeducation/python-graphql-client/issues/28

## What is the new behavior?
See changes comment above

## **Does this PR introduce a breaking change?**
Nope

## Other information
N/A


