### PR TITLE
Support Advanced Usages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
-        language_version: python3.8
+        language_version: python3
   - repo: https://gitlab.com/pycqa/flake8
-    rev: ""
+    rev: "3.8.4"
     hooks:
       - id: flake8
         additional_dependencies: [flake8-docstrings, flake8-isort]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install python-graphql-client
 
 - Query/Mutation
 
-```python
+```py
 from python_graphql_client import GraphqlClient
 
 # Instantiate the client with an endpoint.
@@ -49,7 +49,7 @@ print(data)  # => {'data': {'country': {'code': 'CA', 'name': 'Canada'}}}
 
 - Subscription
 
-```python
+```py
 from python_graphql_client import GraphqlClient
 
 # Instantiate the client with a websocket endpoint.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ asyncio.run(client.subscribe(query=query, handle=print))
 
 ### Disable SSL verification
 
-Set `options` to `{"verify": False}` ether when instantiating the `GraphqlClient` class.
+Set the keyword argument `verify=False` ether when instantiating the `GraphqlClient` class.
 
 ```py
 from python_graphql_client import GraphqlClient

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Set `options` to `{"verify": False}` ether when instantiating the `GraphqlClient
 ```py
 from python_graphql_client import GraphqlClient
 
-client = GraphqlClient(endpoint="wss://www.your-api.com/graphql", options={"verify": False})
+client = GraphqlClient(endpoint="wss://www.your-api.com/graphql", verify=False)
 ```
 
 Alternatively, you can set it when calling the `execute` method.
@@ -90,7 +90,7 @@ Alternatively, you can set it when calling the `execute` method.
 from python_graphql_client import GraphqlClient
 
 client = GraphqlClient(endpoint="wss://www.your-api.com/graphql"
-client.execute(query="<Your Query>", options={"verify": False}))
+client.execute(query="<Your Query>", verify=False))
 ```
 
 ### Custom Authentication

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Alternatively, you can set it when calling the `execute` method.
 from python_graphql_client import GraphqlClient
 
 client = GraphqlClient(endpoint="wss://www.your-api.com/graphql"
-client.execute(query="<Your Query>", verify=False))
+client.execute(query="<Your Query>", verify=False)
 ```
 
 ### Custom Authentication

--- a/README.md
+++ b/README.md
@@ -72,6 +72,37 @@ asyncio.run(client.subscribe(query=query, handle=print))
 # ...
 ```
 
+## Advanced Usage
+
+### Disable SSL verification
+
+Set `options` to `{"verify": False}` ether when instantiating the `GraphqlClient` class.
+
+```py
+from python_graphql_client import GraphqlClient
+
+client = GraphqlClient(endpoint="wss://www.your-api.com/graphql", options={"verify": False})
+```
+
+Alternatively, you can set it when calling the `execute` method.
+
+```py
+from python_graphql_client import GraphqlClient
+
+client = GraphqlClient(endpoint="wss://www.your-api.com/graphql"
+client.execute(query="<Your Query>", options={"verify": False}))
+```
+
+### Custom Authentication
+
+```py
+from requests.auth import HTTPBasicAuth
+from python_graphql_client import GraphqlClient
+
+auth = HTTPBasicAuth('fake@example.com', 'not_a_real_password')
+client = GraphqlClient(endpoint="wss://www.your-api.com/graphql", auth=auth)
+```
+
 ## Roadmap
 
 To start we'll try and use a Github project board for listing current work and updating priorities of upcoming features.

--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -69,7 +69,9 @@ class GraphqlClient:
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                self.endpoint, json=request_body, headers={**self.headers, **headers},
+                self.endpoint,
+                json=request_body,
+                headers={**self.headers, **headers},
             ) as response:
                 return await response.json()
 

--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -13,10 +13,11 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
 class GraphqlClient:
     """Class which represents the interface to make graphQL requests through."""
 
-    def __init__(self, endpoint: str, headers: dict = None):
+    def __init__(self, endpoint: str, headers: dict = {}, options: dict = {}):
         """Insantiate the client."""
         self.endpoint = endpoint
-        self.headers = headers or {}
+        self.headers = headers
+        self.options = options
 
     def __request_body(
         self, query: str, variables: dict = None, operation_name: str = None
@@ -31,15 +32,13 @@ class GraphqlClient:
 
         return json
 
-    def __request_headers(self, headers: dict = None) -> dict:
-        return {**self.headers, **headers} if headers else self.headers
-
     def execute(
         self,
         query: str,
         variables: dict = None,
         operation_name: str = None,
-        headers: dict = None,
+        headers: dict = {},
+        options: dict = {},
     ):
         """Make synchronous request to graphQL server."""
         request_body = self.__request_body(
@@ -49,7 +48,8 @@ class GraphqlClient:
         result = requests.post(
             self.endpoint,
             json=request_body,
-            headers=self.__request_headers(headers),
+            headers={**self.headers, **headers},
+            **{**self.options, **options},
         )
 
         result.raise_for_status()
@@ -60,7 +60,7 @@ class GraphqlClient:
         query: str,
         variables: dict = None,
         operation_name: str = None,
-        headers: dict = None,
+        headers: dict = {},
     ):
         """Make asynchronous request to graphQL server."""
         request_body = self.__request_body(
@@ -69,9 +69,7 @@ class GraphqlClient:
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                self.endpoint,
-                json=request_body,
-                headers=self.__request_headers(headers),
+                self.endpoint, json=request_body, headers={**self.headers, **headers},
             ) as response:
                 return await response.json()
 
@@ -81,7 +79,7 @@ class GraphqlClient:
         handle: Callable,
         variables: dict = None,
         operation_name: str = None,
-        headers: dict = None,
+        headers: dict = {},
     ):
         """Make asynchronous request for GraphQL subscription."""
         connection_init_message = json.dumps({"type": "connection_init", "payload": {}})
@@ -96,7 +94,7 @@ class GraphqlClient:
         async with websockets.connect(
             self.endpoint,
             subprotocols=["graphql-ws"],
-            extra_headers=self.__request_headers(headers),
+            extra_headers={**self.headers, **headers},
         ) as websocket:
             await websocket.send(connection_init_message)
             await websocket.send(request_message)

--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -1,7 +1,7 @@
 """Module containing graphQL client."""
 import json
 import logging
-from typing import Callable
+from typing import Any, Callable
 
 import aiohttp
 import requests
@@ -13,11 +13,11 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
 class GraphqlClient:
     """Class which represents the interface to make graphQL requests through."""
 
-    def __init__(self, endpoint: str, headers: dict = {}, options: dict = {}):
+    def __init__(self, endpoint: str, headers: dict = {}, **kwargs: Any):
         """Insantiate the client."""
         self.endpoint = endpoint
         self.headers = headers
-        self.options = options
+        self.options = kwargs
 
     def __request_body(
         self, query: str, variables: dict = None, operation_name: str = None
@@ -38,7 +38,7 @@ class GraphqlClient:
         variables: dict = None,
         operation_name: str = None,
         headers: dict = {},
-        options: dict = {},
+        **kwargs: Any,
     ):
         """Make synchronous request to graphQL server."""
         request_body = self.__request_body(
@@ -49,7 +49,7 @@ class GraphqlClient:
             self.endpoint,
             json=request_body,
             headers={**self.headers, **headers},
-            **{**self.options, **options},
+            **{**self.options, **kwargs},
         )
 
         result.raise_for_status()

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -104,7 +104,8 @@ class TestGraphqlClientExecute(TestCase):
         """Sends a graphql POST request with headers."""
         auth = HTTPBasicAuth("fake@example.com", "not_a_real_password")
         client = GraphqlClient(
-            endpoint="http://www.test-api.com/", options={"auth": auth},
+            endpoint="http://www.test-api.com/",
+            options={"auth": auth},
         )
         query = ""
         client.execute(query=query, options={"verify": False})

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -4,6 +4,7 @@ from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from aiohttp import web
+from requests.auth import HTTPBasicAuth
 from requests.exceptions import HTTPError
 
 from python_graphql_client import GraphqlClient
@@ -96,6 +97,24 @@ class TestGraphqlClientExecute(TestCase):
                 "Existing": "456",
                 "New": "foo",
             },
+        )
+
+    @patch("python_graphql_client.graphql_client.requests.post")
+    def test_execute_query_with_options(self, post_mock):
+        """Sends a graphql POST request with headers."""
+        auth = HTTPBasicAuth("fake@example.com", "not_a_real_password")
+        client = GraphqlClient(
+            endpoint="http://www.test-api.com/", options={"auth": auth},
+        )
+        query = ""
+        client.execute(query=query, options={"verify": False})
+
+        post_mock.assert_called_once_with(
+            "http://www.test-api.com/",
+            json={"query": query},
+            headers={},
+            auth=HTTPBasicAuth("fake@example.com", "not_a_real_password"),
+            verify=False,
         )
 
     @patch("python_graphql_client.graphql_client.requests.post")
@@ -302,8 +321,4 @@ class TestGraphqlClientSubscriptions(IsolatedAsyncioTestCase):
             extra_headers=expected_headers,
         )
 
-        mock_handle.assert_has_calls(
-            [
-                call({"data": {"messageAdded": "one"}}),
-            ]
-        )
+        mock_handle.assert_has_calls([call({"data": {"messageAdded": "one"}})])

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -105,10 +105,10 @@ class TestGraphqlClientExecute(TestCase):
         auth = HTTPBasicAuth("fake@example.com", "not_a_real_password")
         client = GraphqlClient(
             endpoint="http://www.test-api.com/",
-            options={"auth": auth},
+            auth=auth,
         )
         query = ""
-        client.execute(query=query, options={"verify": False})
+        client.execute(query=query, verify=False)
 
         post_mock.assert_called_once_with(
             "http://www.test-api.com/",


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix #26 fix #32 

## What is the current behavior?

There's no way to specify additional options to configure the underlying `requests` library for advanced usages.

## What is the new behavior?

A new optional parameter `options` is added to the constructor and the `execute` method to support advanced usages like [Custom Authentication](https://requests.readthedocs.io/en/master/user/advanced/#custom-authentication), [SSL Cert Verification](https://requests.readthedocs.io/en/master/user/advanced/#ssl-cert-verification) and [Client Side Certificates](https://requests.readthedocs.io/en/master/user/advanced/#client-side-certificates).

## Does this PR introduce a breaking change?

No

