### PR TITLE
Add ability to override init_payload for subscriptions.

### DIFF
--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -85,7 +85,9 @@ class GraphqlClient:
         init_payload: dict = {},
     ):
         """Make asynchronous request for GraphQL subscription."""
-        connection_init_message = json.dumps({"type": "connection_init", "payload": init_payload})
+        connection_init_message = json.dumps(
+            {"type": "connection_init", "payload": init_payload}
+        )
 
         request_body = self.__request_body(
             query=query, variables=variables, operation_name=operation_name

--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -82,9 +82,10 @@ class GraphqlClient:
         variables: dict = None,
         operation_name: str = None,
         headers: dict = {},
+        init_payload: dict = {},
     ):
         """Make asynchronous request for GraphQL subscription."""
-        connection_init_message = json.dumps({"type": "connection_init", "payload": {}})
+        connection_init_message = json.dumps({"type": "connection_init", "payload": init_payload})
 
         request_body = self.__request_body(
             query=query, variables=variables, operation_name=operation_name


### PR DESCRIPTION
Add init_payload parameter to GraphqlClient.subscribe() allowing
override of payload sent in connection_init call to peer when
initializing the socket.

## What kind of change does this PR introduce?

Minor feature add to allow override of payload when setting up the subscription socket. I have found this useful as some gql subscriptions require information such as tokens etc. in this initial payload. Change should be backwards_compatible. 
