### PR TITLE
CI runs pre-commit

### DIFF
--- a/.github/workflows/python-ci-checks.yml
+++ b/.github/workflows/python-ci-checks.yml
@@ -3,30 +3,10 @@ name: Python CI Checks
 on: [push, pull_request]
 
 jobs:
-  build:
+  pre-commit:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout code to check
-        uses: actions/checkout@v1
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v1
-        with:
-          python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          # Install all necessary packages, including dev dependencies.
-          pip install -e ."[dev]"
-      - name: Check format with black
-        run: |
-          # Check all python files to see if black would format them.
-          # If black would format them, then the check fails.
-          black --check **/*.py
-      - name: Lint with flake8
-        run: |
-          # exit-zero treats all errors as warnings.
-          flake8 .
-      - name: Test with unittest
-        run: |
-          python -m unittest discover -s tests/
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install -e .
+      - uses: pre-commit/action@v2.0.0


### PR DESCRIPTION
## What kind of change does this PR introduce?

It would be more ideal for our CI to run pre-commit to make contributors' lives easier.

## What is the current behavior?

Our CI runs Black, Flake8, and unit tests one by one not using pre-commit while devs run all of them at once using pre-commit. 

![image](https://user-images.githubusercontent.com/5466341/99918251-9a213d00-2ce3-11eb-8395-2917a4ea04aa.png)

This can make contributors and even maintainers feel frustrated and blocked as seen in https://github.com/prodigyeducation/python-graphql-client/pull/30#issuecomment-707829500 or https://github.com/prodigyeducation/python-graphql-client/pull/33#issuecomment-722770231. Things often go wrong in CI when everything looks good locally and if it happens, devs need to run each check manually for troubleshooting.

When CI runs `pip install -e ."[dev]"`, it installs whatever latest version of the dev dependencies.

https://github.com/prodigyeducation/python-graphql-client/blob/9b8fd3b68c3c005df4990d69a6d04faa6122f76b/setup.py#L33-L44

On the other hand, when devs run pre-commit, it uses the specific version of the pre-commit hooks defined.

https://github.com/prodigyeducation/python-graphql-client/blob/9b8fd3b68c3c005df4990d69a6d04faa6122f76b/.pre-commit-config.yaml#L2-L11

## What is the new behavior?

Our CI runs Black, Flake8, and unit tests using pre-commit just like devs do.

![image](https://user-images.githubusercontent.com/5466341/99918145-f6379180-2ce2-11eb-8502-ee21b92bb85c.png)

This will minimize the subtle discrepancy in how checks are run between CI and devs. I believe this will also simplify our CI workflow taking advantage of [the pre-commit Github Action](https://github.com/marketplace/actions/pre-commit).

## **Does this PR introduce a breaking change?**

Nope!