### PR TITLE
Bumping Version for Aiohttp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     author_email="opensource@prodigygame.com",
     license="MIT",
     packages=["python_graphql_client"],
-    install_requires=["aiohttp==3.6.2", "requests==2.22.0", "websockets==8.1"],
+    install_requires=["aiohttp==3.7.3", "requests==2.22.0", "websockets==8.1"],
     extras_require={
         "dev": [
             "pre-commit",


### PR DESCRIPTION
## What kind of change does this PR introduce?

aiohttp has introduced a change https://github.com/aio-libs/aiohttp/pull/5056 in 3.7, to always check for transport is closing before deciding to reuse it.


## What is the current behavior?
On High Load Occasion, a closing transport sometimes will be reused and such errors will be thrown https://github.com/aio-libs/aiohttp/issues/4587

## What is the new behavior?
The latest fix is to always check that transport is not closing before reusing it.



## **Does this PR introduce a breaking change?**

No



## Other information


