### PR TITLE
chore(deps): reduce strictness of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     author_email="opensource@prodigygame.com",
     license="MIT",
     packages=["python_graphql_client"],
-    install_requires=["aiohttp==3.7.3", "requests==2.22.0", "websockets==8.1"],
+    install_requires=["aiohttp~=3.0", "requests~=2.0", "websockets>=5.0"],
     extras_require={
         "dev": [
             "pre-commit",


### PR DESCRIPTION
## What kind of change does this PR introduce?

<!-- > (Bug fix, feature, docs update, ...) -->

Not 100% what to classify this as, but I guess it falls under a feature (non-breaking change).

## What is the current behavior?

<!-- > (You can also link to an open issue here). -->

As per #40, currently projects using this library have to use a very specific version of dependencies which this libraray prescribes. Instead of pinning the versions, we should be allowing all versions of our dependencies which don't break for this project.

## What is the new behavior?

With the change here, the project has converted from using `==` to `>=` for dependency versions. This still keeps some restrictions on anyone who uses this library to make sure the code functions properly, but also more flexibility in dpendency versions which are acceptable for this project.

## **Does this PR introduce a breaking change?**

<!-- > What changes might users need to make in their application due to this PR? -->

No changes, anyone who uses this version of the libraray once it gets released won't have to pin their dependencies with previously limited versions.

## Other information

I did find one bug when testing `requests==1.0.0` which caused the tests to break. Specifically, in past versions of the requests library asserting equality on `HTTPBasicAuth` failed because they were instantiated as two distinct instances of hte class. It seems that this was fixed later on so as the equality check would pass, albeit I'm not sure when this fix was made.

Side note, if anyone is interested in how I automaated the process of checking which versions of the project worked / didn't work, let me know and I can put those steps in the comments on this PR.