### PR TITLE
Stoping Using Root Logger with One-off Logging Setup

### DIFF
--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -7,8 +7,6 @@ import aiohttp
 import requests
 import websockets
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
-
 
 class GraphqlClient:
     """Class which represents the interface to make graphQL requests through."""

--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -13,6 +13,7 @@ class GraphqlClient:
 
     def __init__(self, endpoint: str, headers: dict = {}, **kwargs: Any):
         """Insantiate the client."""
+        self.logger = logging.getLogger(__name__)
         self.endpoint = endpoint
         self.headers = headers
         self.options = kwargs
@@ -104,8 +105,8 @@ class GraphqlClient:
             async for response_message in websocket:
                 response_body = json.loads(response_message)
                 if response_body["type"] == "connection_ack":
-                    logging.info("the server accepted the connection")
+                    self.logger.info("the server accepted the connection")
                 elif response_body["type"] == "ka":
-                    logging.info("the server sent a keep alive message")
+                    self.logger.info("the server sent a keep alive message")
                 else:
                     handle(response_body["payload"])

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -269,9 +269,9 @@ class TestGraphqlClientSubscriptions(IsolatedAsyncioTestCase):
             ]
         )
 
-    @patch("logging.info")
+    @patch("logging.getLogger")
     @patch("websockets.connect")
-    async def test_does_not_crash_with_keep_alive(self, mock_connect, mock_info):
+    async def test_does_not_crash_with_keep_alive(self, mock_connect, mock_get_logger):
         """Subsribe a GraphQL subscription."""
         mock_websocket = mock_connect.return_value.__aenter__.return_value
         mock_websocket.send = AsyncMock()
@@ -288,7 +288,9 @@ class TestGraphqlClientSubscriptions(IsolatedAsyncioTestCase):
 
         await client.subscribe(query=query, handle=MagicMock())
 
-        mock_info.assert_has_calls([call("the server sent a keep alive message")])
+        mock_get_logger.return_value.info.assert_has_calls(
+            [call("the server sent a keep alive message")]
+        )
 
     @patch("websockets.connect")
     async def test_headers_passed_to_websocket_connect(self, mock_connect):


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #43. This PR stops using the root logger that makes it difficult for consumers to configure logging for our library and removes the one-off logging configuration from the library which is totally unnecessary.

## What is the current behavior?

It's difficult for consumers of the library to configure logging for the library specifically.

Let's assume that a consumer has the following logging setup as they want their `INFO` messages are logged.

```py
import logging
import logging.config
import asyncio
from python_graphql_client import GraphqlClient

LOGGING = {
    "version": 1,
    "disable_existing_loggers": False,
    "formatters": {
        "simple": {"format": "[%(levelname)s] %(module)s: %(message)s"},
    },
    "handlers": {
        "console": {"class": "logging.StreamHandler", "formatter": "simple"},
    },
    "root": {
        "handlers": ["console"],
        "level": "INFO",
    },
}
logging.config.dictConfig(LOGGING)

logging.info("Logging in the consumer code...")

client = GraphqlClient(endpoint="ws://localhost:4000/subscriptions")
query = """
    subscription onMessageAdded {
        messageAdded
    }
"""
asyncio.run(client.subscribe(query=query, handle=print))
```

However, the consumer ends up getting `INFO` messages of our library logged as well as their application logs.

```sh
$ python dale_test.py
[INFO] root: Logging in the consumer code...
[INFO] python_graphql_client.graphql_client: the server accepted the connection
{'data': {'messageAdded': 'In ea ratione.'}}
{'data': {'messageAdded': 'Odio consequuntur sit a voluptatem dolorem sint.'}}
```

This is because our library uses the root logger with a one-off logging setup that configures the root logger to log all `INFO` messages.

From the consumer's perspective, this can be annoying because there is no way for them to differentiate their logs from our library logs.

## What is the new behavior?

A simple solution is to stop using the root logger and remove the one-off logging setup from the library. Instead, if we use a logger scoped to the package namespace, consumers will be able to configure logging for the library differently from the rest of their application.

```py
import logging
import logging.config
import asyncio
from python_graphql_client import GraphqlClient

LOGGING = {
    "version": 1,
    "disable_existing_loggers": False,
    "formatters": {
        "simple": {"format": "[%(levelname)s] %(name)s: %(message)s"},
    },
    "handlers": {
        "console": {"class": "logging.StreamHandler", "formatter": "simple"},
    },
    "root": {
        "handlers": ["console"],
        "level": "INFO",
    },
    "loggers": {
        "python_graphql_client": {
            "handlers": ["console"],
            "level": "WARNING",
            "propagate": False,
        }
    },
}
logging.config.dictConfig(LOGGING)

logging.info("Logging in the consumer code...")

client = GraphqlClient(endpoint="ws://localhost:4000/subscriptions")
query = """
    subscription onMessageAdded {
        messageAdded
    }
"""
asyncio.run(client.subscribe(query=query, handle=print))
```

```sh
$ python dale_test.py
[INFO] root: Logging in the consumer code...
{'data': {'messageAdded': 'Qui quia illo facere magnam cum ab consequuntur.'}}
{'data': {'messageAdded': 'Est a optio.'}}
```

## **Does this PR introduce a breaking change?**

This PR will only affect consumers who use subscription operations through this library. They might experience `INFO` logs of our library disappearing depending on their logging setup. I don't believe this a breaking change since it doesn't change any API or behaviors of the library.