### PR TITLE
Fixing #46 by adding an optional argument to disable riase_for_status

### DIFF
--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -37,6 +37,7 @@ class GraphqlClient:
         variables: dict = None,
         operation_name: str = None,
         headers: dict = {},
+        riase_for_status: bool = True,
         **kwargs: Any,
     ):
         """Make synchronous request to graphQL server."""
@@ -50,8 +51,10 @@ class GraphqlClient:
             headers={**self.headers, **headers},
             **{**self.options, **kwargs},
         )
+        
+        if riase_for_status:
+            result.raise_for_status()
 
-        result.raise_for_status()
         return result.json()
 
     async def execute_async(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #46 

## What is the current behavior?

Currently riase_for_status will mask/eat errors from graphql servers that can respond explaining the error.
This allows users to disable that functionality and have the json of the response returned; which would include the error. 

## What is the new behavior?
Default behavior remains the same; however an optional argument is now available that lets user disable the use of riase_for_status to catch errors. 

## **Does this PR introduce a breaking change?**

No; not that I am aware of. 

## Other information
