### PR TITLE
add passing options

### DIFF
--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -72,8 +72,7 @@ class GraphqlClient:
             async with session.post(
                 self.endpoint,
                 json=request_body,
-                headers={**self.headers, **headers},
-                **{**self.options, **kwargs},
+                **{**self.options, **kwargs, "headers": {**self.headers, **headers}},
             ) as response:
                 return await response.json()
 

--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -71,8 +71,12 @@ class GraphqlClient:
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 self.endpoint,
-                json=request_body,
-                **{**self.options, **kwargs, "headers": {**self.headers, **headers}},
+                **{
+                    **self.options,
+                    **kwargs,
+                    "headers": {**self.headers, **headers},
+                    "json": request_body,
+                },
             ) as response:
                 return await response.json()
 

--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -1,4 +1,5 @@
 """Module containing graphQL client."""
+
 import json
 import logging
 from typing import Any, Callable
@@ -60,6 +61,7 @@ class GraphqlClient:
         variables: dict = None,
         operation_name: str = None,
         headers: dict = {},
+        **kwargs: Any,
     ):
         """Make asynchronous request to graphQL server."""
         request_body = self.__request_body(
@@ -71,6 +73,7 @@ class GraphqlClient:
                 self.endpoint,
                 json=request_body,
                 headers={**self.headers, **headers},
+                **{**self.options, **kwargs},
             ) as response:
                 return await response.json()
 

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -172,6 +172,34 @@ class TestGraphqlClientExecuteAsync(IsolatedAsyncioTestCase):
         )
 
     @patch("aiohttp.ClientSession.post")
+    async def test_execute_basic_query_with_aiohttp_parameters(self, mock_post):
+        """Sends a graphql POST request to an endpoint."""
+        mock_post.return_value.__aenter__.return_value.json = AsyncMock()
+        client = GraphqlClient(endpoint="http://www.test-api.com/")
+        query = """
+            {
+                tests {
+                    status
+                }
+            }
+            """
+
+        await client.execute_async(
+            query,
+            timeout=10,
+            verify_ssl=False,
+            headers={"Authorization": "Bearer token"},
+        )
+
+        mock_post.assert_called_once_with(
+            "http://www.test-api.com/",
+            json={"query": query},
+            headers={"Authorization": "Bearer token"},
+            timeout=10,
+            verify_ssl=False,
+        )
+
+    @patch("aiohttp.ClientSession.post")
     async def test_execute_query_with_variables(self, mock_post):
         """Sends a graphql POST request with variables."""
         mock_post.return_value.__aenter__.return_value.json = AsyncMock()


### PR DESCRIPTION
add passing options(Ex: timeout, verify_ssl, ...aiohttp parameters) to execute_async method

## What kind of change does this PR introduce?

feature



## What is the current behavior?

Can not pass additional options to async request



## What is the new behavior?

Can pass additional options to async request

## **Does this PR introduce a breaking change?**

No



## Other information


