### PR TITLE
added support in requests.Session

### DIFF
--- a/python_graphql_client/graphql_client.py
+++ b/python_graphql_client/graphql_client.py
@@ -5,6 +5,7 @@ from typing import Any, Callable
 
 import aiohttp
 import requests
+from requests import Session
 import websockets
 
 
@@ -37,6 +38,7 @@ class GraphqlClient:
         variables: dict = None,
         operation_name: str = None,
         headers: dict = {},
+        session: Session = None,
         **kwargs: Any,
     ):
         """Make synchronous request to graphQL server."""
@@ -44,7 +46,10 @@ class GraphqlClient:
             query=query, variables=variables, operation_name=operation_name
         )
 
-        result = requests.post(
+        if session is None:
+            session = Session()
+
+        result = session.post(
             self.endpoint,
             json=request_body,
             headers={**self.headers, **headers},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added support in requests.Session in order to solve https://github.com/prodigyeducation/python-graphql-client/issues/54


## What is the current behavior?

client.execute() calls to requests.post(), using a session object is not available.



## What is the new behavior?

client.execute() gets a new parameter named `session` that holds a Session object that will be used for making the POST request.
The new parameter is None by default, if its None a new session is created and will be used for making the POST request.


## **Does this PR introduce a breaking change?**

No, you can still skip passing session parameter and the code will act the same as before.



## Other information

This feature allows users to:
1. Log in with a complex flow such as oidc, that sets an authorization cookies for the session
2. Prevent requests from using .netrc file by default, by setting session.trust_env to False:
https://github.com/psf/requests/issues/3929
